### PR TITLE
09-Device_tree_fake_module

### DIFF
--- a/09-DeviceTree/Makefile
+++ b/09-DeviceTree/Makefile
@@ -1,0 +1,32 @@
+NAMELINUX = root@192.168.0.130
+QDIR = /lib/modules/4.19.83-sunxi/kernel/drivers/gpio/
+NAME = fake_module
+KDIR = /home/dmitry/GL/orange-pi-4.19.83
+ARCH = arm
+CCFLAGS = -C
+COMPILER = arm-linux-gnueabihf-
+PWD = $(shell pwd)
+
+obj-m += $(NAME).o
+
+all: $(NAME).c
+	make $(CCFLAGS) $(KDIR) M=$(PWD) ARCH=$(ARCH) CROSS_COMPILE=$(COMPILER) modules
+
+dtbo:
+	~/GL/orange-pi-4.19.83/scripts/dtc/dtc -I dts -O dtb \
+		-o ~/GL/gl-kernel-training-2019/09-DeviceTree/dtsi/fake_module.dtbo \
+		~/GL/gl-kernel-training-2019/09-DeviceTree/dtsi/fake_module.dtsi
+
+copymod: $(NAME).ko
+	scp $< $(NAMELINUX):$(QDIR)
+
+copysshid:
+	ssh-copy-id -i ~/.ssh/id_rsa.pub $(NAMELINUX)
+
+copydtbo:
+	scp ~/GL/gl-kernel-training-2019/09-DeviceTree/dtsi/fake_module.dtbo \
+		$(NAMELINUX):/boot/overlay-user
+
+clean:
+	make $(CCFLAGS) $(KDIR) M=$(PWD) ARCH=$(ARCH) CROSS_COMPILE=$(COMPILER) clean
+	-rm ./dtsi/fake_module.dtbo

--- a/09-DeviceTree/README.md
+++ b/09-DeviceTree/README.md
@@ -1,0 +1,3 @@
+# Homework
+
+Create fake module and overlay dtbo file.

--- a/09-DeviceTree/dtsi/fake_module.dtsi
+++ b/09-DeviceTree/dtsi/fake_module.dtsi
@@ -1,0 +1,16 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+	
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			fake_module@0 {
+				compatible = "orangepi-one,fake-module";
+				status = "okay"; // okay disabled
+			};
+		};
+	};
+};

--- a/09-DeviceTree/fake_module.c
+++ b/09-DeviceTree/fake_module.c
@@ -1,0 +1,47 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/platform_device.h>	/* For platform devices */
+#include <linux/of.h>		/* For DT*/
+#include <linux/device.h>
+
+#define MYDEV_NAME	"FakeModuleDt"
+
+/*----------------------------------------------------------------------------*/
+static int fake_module_probe(struct platform_device *pdev)
+{
+	dev_info(&pdev->dev, "Module started\n");
+
+	return 0;
+}
+/*----------------------------------------------------------------------------*/
+static int fake_module_remove(struct platform_device *pdev)
+{
+	dev_info(&pdev->dev, "Module removed\n");
+
+	return 0;
+}
+/*----------------------------------------------------------------------------*/
+static const struct of_device_id fake_module_ids[] = {
+	{ .compatible = "orangepi-one,fake-module" },
+	{ /* sentinel */ },
+};
+MODULE_DEVICE_TABLE(of, fake_module_ids);
+/*----------------------------------------------------------------------------*/
+static struct platform_driver fake_module = {
+	.probe = fake_module_probe,
+	.remove = fake_module_remove,
+	.driver = {
+		.name = "fake-module-dt",
+		.of_match_table = of_match_ptr(fake_module_ids),
+		.owner = THIS_MODULE,
+	},
+};
+module_platform_driver(fake_module);
+/*----------------------------------------------------------------------------*/
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Domnin Dmitry");
+MODULE_DESCRIPTION("A simple fake module, which is start from device tree");
+MODULE_VERSION("0.1");
+MODULE_SUPPORTED_DEVICE(MYDEV_NAME);
+/*----------------------------------------------------------------------------*/

--- a/09-DeviceTree/result/dmesg.txt
+++ b/09-DeviceTree/result/dmesg.txt
@@ -1,0 +1,78 @@
+dmitry@orangepione:~$ dmesg
+[    2.213202] of_cfs_init
+[    2.213302] of_cfs_init: OK
+[    2.216820] Freeing unused kernel memory: 1024K
+[    2.233155] Run /init as init process
+[    2.909139] [drm] Cannot find any crtc or sizes
+[    3.068917] random: fast init done
+[    3.086544] EXT4-fs (mmcblk0p1): mounted filesystem with writeback data mode. Opts: (null)
+[    3.814488] systemd[1]: System time before build time, advancing clock.
+[    3.865176] systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    3.865822] systemd[1]: Detected architecture arm.
+[    3.890015] systemd[1]: Set hostname to <orangepione>.
+[    3.891809] systemd[1]: Failed to bump fs.file-max, ignoring: Invalid argument
+[    4.509913] random: systemd: uninitialized urandom read (16 bytes read)
+[    4.521796] random: systemd: uninitialized urandom read (16 bytes read)
+[    4.522352] systemd[1]: Started Dispatch Password Requests to Console Directory Watch.
+[    4.541161] random: systemd: uninitialized urandom read (16 bytes read)
+[    4.541710] systemd[1]: Listening on udev Control Socket.
+[    4.560326] systemd[1]: Listening on Syslog Socket.
+[    4.573145] systemd[1]: Reached target Remote File Systems.
+[    4.585456] systemd[1]: Listening on Journal Socket (/dev/log).
+[    4.601317] systemd[1]: Created slice system-getty.slice.
+[    4.980121] EXT4-fs (mmcblk0p1): re-mounted. Opts: commit=600,errors=remount-ro
+[    5.389670] systemd-journald[234]: Received request to flush runtime journal from PID 1
+[    5.845299] fake_module: loading out-of-tree module taints kernel.
+[    5.846030] fake-module-dt fake_module@0: Module started
+[    5.853486] cpu cpu0: Linked as a consumer to regulator.5
+[    5.854124] cpu cpu0: Dropping the link to regulator.5
+[    5.854358] cpu cpu0: Linked as a consumer to regulator.5
+[    5.855136] core: _opp_supported_by_regulators: OPP minuV: 1320000 maxuV: 1320000, not supported by regulator
+[    5.855147] cpu cpu0: _opp_add: OPP not supported by regulators (1056000000)
+[    5.855226] core: _opp_supported_by_regulators: OPP minuV: 1320000 maxuV: 1320000, not supported by regulator
+[    5.855233] cpu cpu0: _opp_add: OPP not supported by regulators (1104000000)
+[    5.855341] core: _opp_supported_by_regulators: OPP minuV: 1320000 maxuV: 1320000, not supported by regulator
+[    5.855349] cpu cpu0: _opp_add: OPP not supported by regulators (1152000000)
+[    5.855450] core: _opp_supported_by_regulators: OPP minuV: 1320000 maxuV: 1320000, not supported by regulator
+[    5.855457] cpu cpu0: _opp_add: OPP not supported by regulators (1200000000)
+[    5.855543] core: _opp_supported_by_regulators: OPP minuV: 1340000 maxuV: 1340000, not supported by regulator
+[    5.855551] cpu cpu0: _opp_add: OPP not supported by regulators (1224000000)
+[    5.855668] core: _opp_supported_by_regulators: OPP minuV: 1340000 maxuV: 1340000, not supported by regulator
+[    5.855676] cpu cpu0: _opp_add: OPP not supported by regulators (1248000000)
+[    5.855803] core: _opp_supported_by_regulators: OPP minuV: 1340000 maxuV: 1340000, not supported by regulator
+[    5.855812] cpu cpu0: _opp_add: OPP not supported by regulators (1296000000)
+[    5.855907] core: _opp_supported_by_regulators: OPP minuV: 1400000 maxuV: 1400000, not supported by regulator
+[    5.855915] cpu cpu0: _opp_add: OPP not supported by regulators (1344000000)
+[    5.856038] core: _opp_supported_by_regulators: OPP minuV: 1400000 maxuV: 1400000, not supported by regulator
+[    5.856046] cpu cpu0: _opp_add: OPP not supported by regulators (1368000000)
+[    5.856513] thermal thermal_zone0: binding zone cpu-thermal with cdev thermal-cpufreq-0 failed:-22
+[    5.861694] zram: Added device: zram0
+[    5.866599] zram: Added device: zram1
+[    5.867276] zram: Added device: zram2
+[    5.989953] sun8i_ths 1c25000.thermal-sensor: no memory resources defined
+[    5.989988] sun8i_ths: probe of 1c25000.thermal-sensor failed with error -22
+[    6.012507] thermal thermal_zone0: failed to read out thermal zone (-110)
+[    6.022345] zram1: detected capacity change from 0 to 258437120
+[    6.103373] lima 1c40000.gpu: bus rate = 200000000
+[    6.103394] lima 1c40000.gpu: mod rate = 384000000
+[    6.108165] [TTM] Zone  kernel: Available graphics memory: 252380 kiB
+[    6.108176] [TTM] Initializing pool allocator
+[    6.109172] lima 1c40000.gpu: gp - mali400 version major 1 minor 1
+[    6.109228] lima 1c40000.gpu: pp0 - mali400 version major 1 minor 1
+[    6.109280] lima 1c40000.gpu: pp1 - mali400 version major 1 minor 1
+[    6.109333] lima 1c40000.gpu: l2 cache 64K, 4-way, 64byte cache line, 64bit external bus
+[    6.122711] [drm] Initialized lima 1.0.0 20170325 for 1c40000.gpu on minor 1
+[    6.410216] asoc-simple-card soc:sound: i2s-hifi <-> 1c22800.i2s mapping ok
+[    6.903715] Generic PHY 0.1:01: attached PHY driver [Generic PHY] (mii_bus:phy_addr=0.1:01, irq=POLL)
+[    6.905758] dwmac-sun8i 1c30000.ethernet eth0: No Safety Features support found
+[    6.905773] dwmac-sun8i 1c30000.ethernet eth0: No MAC Management Counters available
+[    6.905781] dwmac-sun8i 1c30000.ethernet eth0: PTP not supported by HW
+[    6.906271] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
+[    7.117556] Adding 252376k swap on /dev/zram1.  Priority:5 extents:1 across:252376k SSFS
+[    7.264857] zram0: detected capacity change from 0 to 52428800
+[    7.463299] random: crng init done
+[    7.463312] random: 7 urandom warning(s) missed due to ratelimiting
+[    7.792428] EXT4-fs (zram0): mounted filesystem without journal. Opts: discard
+[    9.981516] dwmac-sun8i 1c30000.ethernet eth0: Link is Up - 100Mbps/Full - flow control rx/tx
+[    9.981561] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+

--- a/09-DeviceTree/result/lsmod.txt
+++ b/09-DeviceTree/result/lsmod.txt
@@ -1,0 +1,32 @@
+dmitry@orangepione:~$ lsmod
+Module                  Size  Used by
+zstd                   16384  4
+snd_soc_hdmi_codec     16384  1
+sun8i_codec_analog     24576  0
+sun4i_i2s              20480  2
+snd_soc_simple_card    16384  1
+sun8i_adda_pr_regmap    16384  1 sun8i_codec_analog
+snd_soc_simple_card_utils    16384  1 snd_soc_simple_card
+lima                   40960  0
+snd_soc_core          110592  5 sun4i_i2s,sun8i_codec_analog,snd_soc_hdmi_codec,snd_soc_simple_card_utils,snd_soc_simple_card
+dw_hdmi_cec            16384  0
+dw_hdmi_i2s_audio      16384  0
+snd_pcm_dmaengine      16384  1 snd_soc_core
+gpu_sched              20480  1 lima
+snd_pcm                69632  4 sun4i_i2s,snd_pcm_dmaengine,snd_soc_hdmi_codec,snd_soc_core
+ttm                    57344  1 lima
+snd_timer              24576  1 snd_pcm
+snd                    45056  6 snd_soc_hdmi_codec,snd_timer,snd_soc_core,snd_pcm
+sun4i_gpadc_iio        16384  0
+soundcore              16384  1 snd
+industrialio           49152  1 sun4i_gpadc_iio
+sun8i_ths              16384  0
+zram                   24576  2
+cpufreq_dt             16384  0
+evdev                  20480  1
+fake_module            16384  0
+uio_pdrv_genirq        16384  0
+thermal_sys            57344  3 cpufreq_dt,sun8i_ths,sun4i_gpadc_iio
+uio                    16384  1 uio_pdrv_genirq
+ip_tables              20480  0
+x_tables               20480  1 ip_tables

--- a/09-DeviceTree/result/start_u-boot.txt
+++ b/09-DeviceTree/result/start_u-boot.txt
@@ -1,0 +1,234 @@
+U-Boot SPL 2019.04-armbian (Dec 01 2019 - 12:47:04 +0200)
+DRAM: 512 MiB
+Trying to boot from MMC1
+
+
+U-Boot 2019.04-armbian (Dec 01 2019 - 12:47:04 +0200) Allwinner Technology
+
+CPU:   Allwinner H3 (SUN8I 1680)
+Model: Xunlong Orange Pi One
+DRAM:  512 MiB
+MMC:   mmc@1c0f000: 0
+Loading Environment from EXT4... ** File not found /boot/boot.env **
+
+** Unable to read "/boot/boot.env" from mmc0:1 **
+In:    serial
+Out:   serial
+Err:   serial
+Net:   phy interface0
+eth0: ethernet@1c30000
+** Reading file would overwrite reserved memory **
+There is no valid bmp file at the given address
+starting USB...
+USB0:   USB EHCI 1.00
+USB1:   USB OHCI 1.0
+USB2:   USB EHCI 1.00
+USB3:   USB OHCI 1.0
+scanning bus 0 for devices... 1 USB Device(s) found
+scanning bus 1 for devices... 1 USB Device(s) found
+scanning bus 2 for devices... 1 USB Device(s) found
+scanning bus 3 for devices... 1 USB Device(s) found
+       scanning usb for storage devices... 0 Storage Device(s) found
+Autoboot in 1 seconds, press <Space> to stop
+switch to partitions #0, OK
+mmc0 is current device
+Scanning mmc 0:1...
+Found U-Boot script /boot/boot.scr
+3798 bytes read in 2 ms (1.8 MiB/s)
+## Executing script at 43100000
+U-boot loaded from SD
+Boot script loaded from mmc
+248 bytes read in 2 ms (121.1 KiB/s)
+6842649 bytes read in 333 ms (19.6 MiB/s)
+7430672 bytes read in 362 ms (19.6 MiB/s)
+Found mainline kernel configuration
+29878 bytes read in 9 ms (3.2 MiB/s)
+374 bytes read in 6 ms (60.5 KiB/s)
+Applying kernel provided DT overlay sun8i-h3-i2c0.dtbo
+374 bytes read in 2 ms (182.6 KiB/s)
+Applying kernel provided DT overlay sun8i-h3-i2c1.dtbo
+274 bytes read in 3 ms (88.9 KiB/s)
+Applying user provided DT overlay fake_module.dtbo
+4155 bytes read in 3 ms (1.3 MiB/s)
+Applying kernel provided DT fixup script (sun8i-h3-fixup.scr)
+## Executing script at 44000000
+## Loading init Ramdisk from Legacy Image at 43300000 ...
+   Image Name:   uInitrd
+   Image Type:   ARM Linux RAMDisk Image (gzip compressed)
+   Data Size:    6842585 Bytes = 6.5 MiB
+   Load Address: 00000000
+   Entry Point:  00000000
+   Verifying Checksum ... OK
+## Flattened Device Tree blob at 43000000
+   Booting using the fdt blob at 0x43000000
+EHCI failed to shut down host controller.
+   Loading Ramdisk to 49979000, end 49fff8d9 ... OK
+   Loading Device Tree to 49909000, end 49978fff ... OK
+
+Starting kernel ...
+
+Uncompressing Linux... done, booting the kernel.
+Loading, please wait...
+Starting version 241
+Begin: Loading essential drivers ... done.
+Begin: Running /scripts/init-premount ... done.
+Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
+Begin: Running /scripts/local-premount ... Scanning for Btrfs filesystems
+done.
+Begin: Will now check root file system ... fsck from util-linux 2.33.1
+[/sbin/fsck.ext4 (1) -- /dev/mmcblk0p1] fsck.ext4 -a -C0 /dev/mmcblk0p1 
+/dev/mmcblk0p1: clean, 37580/228928 files, 277256/912384 blocks
+done.
+done.
+Begin: Running /scripts/local-bottom ... done.
+Begin: Running /scripts/init-bottom ... done.
+
+Welcome to Debian GNU/Linux 10 (buster)!
+
+[  OK  ] Started Dispatch Password …ts to Console Directory Watch.
+[  OK  ] Listening on udev Control Socket.
+[  OK  ] Listening on Syslog Socket.
+[  OK  ] Reached target Remote File Systems.
+[  OK  ] Listening on Journal Socket (/dev/log).
+[  OK  ] Created slice system-getty.slice.
+[  OK  ] Set up automount Arbitrary…s File System Automount Point.
+[  OK  ] Listening on udev Kernel Socket.
+[  OK  ] Reached target System Time Synchronized.
+[  OK  ] Listening on Journal Socket.
+         Mounting POSIX Message Queue File System...
+         Starting Restore / save the current clock...
+         Starting Create list of re…odes for the current kernel...
+         Starting Set the console keyboard layout...
+         Starting Nameserver information manager...
+[  OK  ] Listening on fsck to fsckd communication Socket.
+[  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+[  OK  ] Reached target Paths.
+         Mounting Kernel Debug File System...
+[  OK  ] Listening on Journal Audit Socket.
+         Starting Journal Service...
+[  OK  ] Created slice system-serial\x2dgetty.slice.
+[  OK  ] Reached target Swap.
+         Starting Load Kernel Modules...
+         Starting Remount Root and Kernel File Systems...
+[  OK  ] Listening on initctl Compatibility Named Pipe.
+[  OK  ] Created slice User and Session Slice.
+[  OK  ] Reached target Slices.
+[  OK  ] Reached target Local Encrypted Volumes.
+         Starting udev Coldplug all Devices...
+[  OK  ] Mounted POSIX Message Queue File System.
+[  OK  ] Started Restore / save the current clock.
+[  OK  ] Started Create list of req… nodes for the current kernel.
+[  OK  ] Mounted Kernel Debug File System.
+[  OK  ] Started Load Kernel Modules.
+[  OK  ] Started Journal Service.
+[  OK  ] Started Remount Root and Kernel File Systems.
+[  OK  ] Started Nameserver information manager.
+[  OK  ] Started Set the console keyboard layout.
+         Starting Create System Users...
+         Starting Load/Save Random Seed...
+         Starting Flush Journal to Persistent Storage...
+         Starting Apply Kernel Variables...
+         Mounting Kernel Configuration File System...
+[  OK  ] Started Load/Save Random Seed.
+[  OK  ] Started Create System Users.
+[  OK  ] Started Apply Kernel Variables.
+[  OK  ] Mounted Kernel Configuration File System.
+         Starting Create Static Device Nodes in /dev...
+[  OK  ] Started udev Coldplug all Devices.
+         Starting Helper to synchronize boot up for ifupdown...
+[  OK  ] Started Flush Journal to Persistent Storage.
+[  OK  ] Started Create Static Device Nodes in /dev.
+         Starting udev Kernel Device Manager...
+[  OK  ] Reached target Local File Systems (Pre).
+         Mounting /tmp...
+[  OK  ] Mounted /tmp.
+[  OK  ] Reached target Local File Systems.
+         Starting Armbian ZRAM config...
+         Starting Set console font and keymap...
+         Starting Create Volatile Files and Directories...
+[  OK  ] Started Set console font and keymap.
+[  OK  ] Started udev Kernel Device Manager.
+[  OK  ] Started Create Volatile Files and Directories.
+[  OK  ] Started Entropy daemon using the HAVEGE algorithm.
+         Starting Update UTMP about System Boot/Shutdown...
+[  OK  ] Started Update UTMP about System Boot/Shutdown.
+[  OK  ] Found device /dev/ttyS0.
+[  OK  ] Listening on Load/Save RF …itch Status /dev/rfkill Watch.
+[  OK  ] Started Helper to synchronize boot up for ifupdown.
+         Starting Raise network interfaces...
+[  OK  ] Started Raise network interfaces.
+[  OK  ] Started Armbian ZRAM config.
+         Starting Armbian memory supported logging...
+[  OK  ] Started Armbian memory supported logging.
+[  OK  ] Reached target System Initialization.
+         Starting Armbian hardware optimization...
+[  OK  ] Started Daily man-db regeneration.
+[  OK  ] Started Daily apt download activities.
+         Starting Armbian hardware monitoring...
+[  OK  ] Started Daily apt upgrade and clean activities.
+[  OK  ] Started Daily Cleanup of Temporary Directories.
+[  OK  ] Started Daily rotation of log files.
+[  OK  ] Reached target Timers.
+[  OK  ] Listening on D-Bus System Message Bus Socket.
+[  OK  ] Reached target Sockets.
+[  OK  ] Started Armbian hardware optimization.
+[  OK  ] Started Armbian hardware monitoring.
+[  OK  ] Reached target Basic System.
+         Starting System Logging Service...
+         Starting LSB: Load kernel …d to enable cpufreq scaling...
+[  OK  ] Started Manage Sound Card State (restore and store).
+         Starting rng-tools.service...
+         Starting Dispatcher daemon for systemd-networkd...
+[  OK  ] Started D-Bus System Message Bus.
+[  OK  ] Started Regular background program processing daemon.
+         Starting Save/Restore Sound Card State...
+         Starting WPA supplicant...
+         Starting Login Service...
+         Starting Resets System Activity Data Collector...
+         Starting Network Manager...
+[  OK  ] Started rng-tools.service.
+[  OK  ] Started Save/Restore Sound Card State.
+[  OK  ] Reached target Sound Card.
+[  OK  ] Started System Logging Service.
+[  OK  ] Started Resets System Activity Data Collector.
+[  OK  ] Started Login Service.
+[  OK  ] Started WPA supplicant.
+[  OK  ] Started LSB: Load kernel m…ded to enable cpufreq scaling.
+         Starting LSB: set CPUFreq kernel parameters...
+[  OK  ] Started LSB: set CPUFreq kernel parameters.
+         Starting LSB: Set sysfs variables from /etc/sysfs.conf...
+[  OK  ] Started Network Manager.
+[  OK  ] Reached target Network.
+         Starting OpenBSD Secure Shell server...
+[  OK  ] Started Unattended Upgrades Shutdown.
+         Starting Permit User Sessions...
+         Starting chrony, an NTP client/server...
+         Starting Network Manager Wait Online...
+[  OK  ] Started LSB: Set sysfs variables from /etc/sysfs.conf.
+[  OK  ] Started Permit User Sessions.
+         Starting Hostname Service...
+[  OK  ] Started OpenBSD Secure Shell server.
+[  OK  ] Started chrony, an NTP client/server.
+[  OK  ] Started Dispatcher daemon for systemd-networkd.
+[  OK  ] Started Hostname Service.
+         Starting Network Manager Script Dispatcher Service...
+[  OK  ] Started Network Manager Script Dispatcher Service.
+         Starting Authorization Manager...
+[  OK  ] Started Network Manager Wait Online.
+[  OK  ] Started Authorization Manager.
+[  OK  ] Reached target Network is Online.
+         Starting LSB: Advanced IEEE 802.11 management daemon...
+         Starting /etc/rc.local Compatibility...
+[  OK  ] Started LSB: Advanced IEEE 802.11 management daemon.
+[  OK  ] Started /etc/rc.local Compatibility.
+[  OK  ] Started Serial Getty on ttyS0.
+[  OK  ] Started Getty on tty1.
+[  OK  ] Reached target Login Prompts.
+[  OK  ] Reached target Multi-User System.
+[  OK  ] Reached target Graphical Interface.
+         Starting Update UTMP about System Runlevel Changes...
+[  OK  ] Started Update UTMP about System Runlevel Changes.
+
+Armbian 19.11.3 Buster ttyS0 
+
+orangepione login:


### PR DESCRIPTION
This is fake-module and dts.
Start steps:
1. Make module and dtsi;
2. Copy module .ko to {orange}/lib/modules/{kernel}/kernel/drivers/gpio;
3. Copy overlay .dtbo to {orange}/boot/overlay-user;
4. Add string "user_overlays=fake_module" to {orange}/boot/armbianEnv.txt;
5. Enter "depmod -a" on orange;
6. Orange reboot.